### PR TITLE
ci: bump gh-page deploy to Node 20

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -15,7 +15,7 @@ jobs:
               uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: '16'
+                  node-version: '20'
             - name: Authenticate with private NPM package
               run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
             - name: Install


### PR DESCRIPTION
## Summary
The previous Node 16 pin causes EBADENGINE warnings for playwright, @vitejs/plugin-vue, esbuild (all require Node >=18) and a broken `npm install` that left `@ultraos/wallet-sdk` types unresolvable at build time on the most recent main-push.

Run that failed: https://github.com/ultraio/ultra-tool-kit/actions/runs/25922912265

Bump to LTS 20.

## Test plan
- [ ] CI passes
- [ ] After merge, gh-page.yml deploys successfully