### PR TITLE
chore(deps): bump @ultraos/wallet-sdk to ^0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@ultraos/ultra-api-lib": "^1.1.0",
                 "@ultraos/ultra-ledger-lib": "^2.0.2",
                 "@ultraos/ultra-signer-lib": "1.6.4",
-                "@ultraos/wallet-sdk": "^0.3.0",
+                "@ultraos/wallet-sdk": "^0.3.1",
                 "@vitejs/plugin-basic-ssl": "^1.2.0",
                 "@wharfkit/session": "^1.0.0",
                 "@wharfkit/wallet-plugin-anchor": "^1.0.0",
@@ -50,7 +50,7 @@
         },
         "../web-app/dist/libs/wallet-sdk": {
             "name": "@ultraos/wallet-sdk",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "dependencies": {
                 "json-rpc-2.0": "^1.7.0",
                 "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@ultraos/ultra-api-lib": "^1.1.0",
         "@ultraos/ultra-ledger-lib": "^2.0.2",
         "@ultraos/ultra-signer-lib": "1.6.4",
-        "@ultraos/wallet-sdk": "^0.3.0",
+        "@ultraos/wallet-sdk": "^0.3.1",
         "@vitejs/plugin-basic-ssl": "^1.2.0",
         "@wharfkit/session": "^1.0.0",
         "@wharfkit/wallet-plugin-anchor": "^1.0.0",


### PR DESCRIPTION
Fixes the gh-page deploy failure (run 25950082588) where `vue-tsc` couldn't resolve `@ultraos/wallet-sdk` types under `moduleResolution: bundler`. 0.3.1 republishes with the `typings` field present.