### PR TITLE
fix(e2e): update trusted-apps shape assertions + invert C-N2

### DIFF
--- a/tests/e2e/audit-c-n2.e2e.spec.mjs
+++ b/tests/e2e/audit-c-n2.e2e.spec.mjs
@@ -270,7 +270,7 @@ test.describe('Audit C-N2: silent network takeover via trusted dapp', () => {
         }
     });
 
-    test('trusted dapp can silently addNetwork + switchNetwork → signing endpoint becomes attacker RPC', async () => {
+    test('trusted dapp CANNOT silently addNetwork/switchNetwork → takeover blocked (N-N1)', async () => {
         const dappServer = await startDappServer();
         const { server: attackerServer, stats } = await startAttackerRpc();
 
@@ -350,9 +350,14 @@ test.describe('Audit C-N2: silent network takeover via trusted dapp', () => {
                 { name: ATTACKER_NAME_SPOOF, chainId: ATTACKER_CHAIN_ID, nodeUrl: ATTACKER_RPC },
             );
             console.log('[test] addNetwork result:', JSON.stringify(addResult));
-            expect(addResult.ok, 'addNetwork must succeed silently for a trusted dapp').toBeTruthy();
+            // N-N1 fix: the dapp-callable addNetwork handler was REMOVED (zero
+            // legitimate callers; it was the silent-takeover vector). A trusted dapp
+            // calling window.ultra.addNetwork must now be REJECTED, never silently
+            // persisting an attacker network.
+            expect(addResult.ok, 'addNetwork must be REJECTED for a dapp (N-N1 handler removed)').toBe(false);
 
-            // STEP 2: silent switchNetwork.
+            // STEP 2: switchNetwork to the attacker chain must also fail — the network
+            // was never added, so it is an unrecognized chain id.
             const switchResult = await page.evaluate(async (chainId) => {
                 try {
                     const r = await window.ultra.switchNetwork(chainId);
@@ -362,64 +367,46 @@ test.describe('Audit C-N2: silent network takeover via trusted dapp', () => {
                 }
             }, ATTACKER_CHAIN_ID);
             console.log('[test] switchNetwork result:', JSON.stringify(switchResult));
-            expect(switchResult.ok, 'switchNetwork must succeed silently').toBeTruthy();
+            expect(switchResult.ok, 'switchNetwork to the un-added attacker chain must be rejected').toBe(false);
 
-            // STEP 3: confirm wallet state was actually flipped.
+            // STEP 3: the wallet's active network must NOT have flipped to the attacker.
             await new Promise((r) => setTimeout(r, 500));
             const envAfter = await getEnvironment(sw);
-            console.log('[test] post-attack ENVIRONMENT/CUSTOM_*:', JSON.stringify(envAfter, null, 2));
-            expect(envAfter.ENVIRONMENT).toBe(ATTACKER_CHAIN_ID);
+            console.log('[test] post-attempt ENVIRONMENT/CUSTOM_*:', JSON.stringify(envAfter, null, 2));
+            expect(envAfter.ENVIRONMENT, 'ENVIRONMENT must not be the attacker chain').not.toBe(ATTACKER_CHAIN_ID);
 
-            // The CUSTOM_NETWORKS record should now contain a network named
-            // "Ultra Mainnet" pointing at the attacker URL. That's the takeover.
+            // The attacker network must NOT have been persisted anywhere.
             const customNets = envAfter.CUSTOM_NETWORKS || [];
-            const spoofed = customNets.find((n) => n.chainId === ATTACKER_CHAIN_ID);
-            expect(spoofed, 'attacker network must be persisted in CUSTOM_NETWORKS').toBeTruthy();
-            expect(spoofed.name).toBe(ATTACKER_NAME_SPOOF);
-            expect(spoofed.nodeUrl).toBe(ATTACKER_RPC);
+            expect(
+                customNets.find((n) => n.chainId === ATTACKER_CHAIN_ID),
+                'attacker network must NOT be persisted in CUSTOM_NETWORKS',
+            ).toBeFalsy();
 
-            // STEP 4: confirm getNetwork() now returns the spoofed metadata.
-            const netOut = await page.evaluate(async () => {
-                const r = await window.ultra.getNetwork();
-                return r;
-            });
-            console.log('[test] getNetwork after switch:', JSON.stringify(netOut));
-
-            // STEP 5: try to sign. We don't drive the full UI here; we directly
-            // observe that the wallet's getEnvConfig() (which is the source for
-            // wallet.service.ts:signTransaction's `endpoint`) returns the
-            // attacker URL post-switch. That's the load-bearing assertion: every
-            // sign performed after this point uses the attacker RPC for ABI
-            // fetch AND push_transaction.
+            // STEP 4: getEnvConfig() — the source of signTransaction's endpoint — must
+            // NOT resolve to the attacker RPC.
             const envConfig = await sw.evaluate(async () => {
-                // Pull the same data EnvManager.getEnvConfig() pulls.
                 const r = await chrome.storage.local.get(['ENVIRONMENT', 'CUSTOM_ENVIRONMENTS']);
                 const envName = r.ENVIRONMENT;
                 const customEnvs = r.CUSTOM_ENVIRONMENTS || {};
                 return { envName, fromCustom: customEnvs[envName] };
             });
-            console.log('[test] envConfig post-switch:', JSON.stringify(envConfig));
-            expect(envConfig.envName).toBe(ATTACKER_CHAIN_ID);
-            expect(envConfig.fromCustom.blockchainUrl).toBe(ATTACKER_RPC);
-            expect(envConfig.fromCustom.name).toBe(ATTACKER_NAME_SPOOF);
+            console.log('[test] envConfig post-attempt:', JSON.stringify(envConfig));
+            expect(envConfig.envName).not.toBe(ATTACKER_CHAIN_ID);
+            expect(envConfig.fromCustom?.blockchainUrl).not.toBe(ATTACKER_RPC);
 
-            // STEP 6: confirm the attacker RPC was actually called during the
-            // addNetwork chain_id verification.
+            // STEP 5: the attacker RPC must never have been contacted — addNetwork was
+            // rejected before any chain_id probe could fire.
             const s = stats();
             console.log('[test] attacker RPC hit counts:', s);
-            expect(s.hitInfo, 'addNetwork must have called attacker /v1/chain/get_info').toBeGreaterThanOrEqual(1);
+            expect(s.hitInfo, 'attacker /v1/chain/get_info must NOT be called — addNetwork was blocked').toBe(0);
 
             console.log(
-                '\n=== AUDIT C-N2 VERIFIED ===\n' +
-                    `Trusted dapp ${dappOrigin} silently:\n` +
-                    `  - Added network "${ATTACKER_NAME_SPOOF}" (name-spoofed built-in)\n` +
-                    `  - chainId=${ATTACKER_CHAIN_ID}\n` +
-                    `  - nodeUrl=${ATTACKER_RPC} (attacker-controlled)\n` +
-                    `  - Switched wallet to it (ENVIRONMENT=${ATTACKER_CHAIN_ID})\n` +
-                    `  - chain_id cross-check was bypassed because attacker controls the RPC's get_info response\n` +
-                    `  - Subsequent signTransaction will use endpoint=${ATTACKER_RPC} for get_abi + push_transaction\n` +
-                    `  - Signing popup network label will show "${ATTACKER_NAME_SPOOF}" (spoofed)\n` +
-                    `  - No popup or user gesture appeared at any point\n`,
+                '\n=== AUDIT C-N2: takeover BLOCKED (N-N1) ===\n' +
+                    `Trusted dapp ${dappOrigin} attempted a silent network takeover and was blocked:\n` +
+                    `  - addNetwork("${ATTACKER_NAME_SPOOF}", ${ATTACKER_RPC}) → REJECTED\n` +
+                    `  - switchNetwork(${ATTACKER_CHAIN_ID}) → REJECTED (unrecognized chain)\n` +
+                    `  - ENVIRONMENT unchanged (not the attacker chain)\n` +
+                    `  - No attacker network persisted; attacker RPC never contacted\n`,
             );
         } finally {
             await context.close();

--- a/tests/e2e/wallet-disconnect-connect.e2e.spec.ts
+++ b/tests/e2e/wallet-disconnect-connect.e2e.spec.ts
@@ -274,7 +274,18 @@ async function waitForListenerMap(sw: Worker, timeoutMs = 30_000): Promise<void>
 async function readTrustedApps(sw: Worker): Promise<Record<string, string[]>> {
   return sw.evaluate(async () => {
     const r = await chrome.storage.local.get('TRUSTED_APPS');
-    return (r?.TRUSTED_APPS ?? {}) as Record<string, string[]>;
+    // Trusted-apps entries are now `{ origin, attestationConsentedAt? }` objects
+    // (per-origin metadata added by the wallet-attestation feature); they were
+    // bare origin strings before. Normalize to origin strings so callers can
+    // assert membership regardless of which shape is on disk.
+    const raw = (r?.TRUSTED_APPS ?? {}) as Record<string, Array<string | { origin?: string }>>;
+    const out: Record<string, string[]> = {};
+    for (const [env, entries] of Object.entries(raw)) {
+      out[env] = Array.isArray(entries)
+        ? entries.map((e) => (typeof e === 'string' ? e : e?.origin)).filter((o): o is string => !!o)
+        : [];
+    }
+    return out;
   });
 }
 
@@ -369,13 +380,15 @@ test.describe('Wallet ↔ Toolkit disconnect/connect parity', () => {
       // `listenMessages` filter (`message.to === CONTENT_SCRIPT`) lets it
       // through to the page bridge.
       await sw.evaluate(async (origin) => {
-        // (1) Cross-env removal — replicates PermissionService.removeOriginEverywhere
+        // (1) Cross-env removal — replicates PermissionService.removeOriginEverywhere.
+        // Entries are `{ origin, attestationConsentedAt? }` objects (per-origin
+        // metadata from the wallet-attestation feature); compare on the origin field.
         const r = await chrome.storage.local.get('TRUSTED_APPS');
-        const map = (r?.TRUSTED_APPS ?? {}) as Record<string, string[]>;
+        const map = (r?.TRUSTED_APPS ?? {}) as Record<string, Array<string | { origin?: string }>>;
         let mutated = false;
         for (const env of Object.keys(map)) {
           const before = map[env] ?? [];
-          const next = before.filter((o) => o !== origin);
+          const next = before.filter((e) => (typeof e === 'string' ? e : e?.origin) !== origin);
           if (next.length !== before.length) {
             map[env] = next;
             mutated = true;

--- a/tests/e2e/wallet-network-sync.e2e.spec.ts
+++ b/tests/e2e/wallet-network-sync.e2e.spec.ts
@@ -1090,8 +1090,13 @@ test.describe('Wallet ↔ Toolkit network sync (real extension)', () => {
                 return r?.TRUSTED_APPS ?? null;
             });
             expect(trusted, 'TRUSTED_APPS missing or wrong shape').toBeTruthy();
+            // Entries are now `{ origin, attestationConsentedAt? }` objects (per-origin
+            // metadata from the wallet-attestation feature); map to origin strings.
+            const testnetTrusted = ((trusted as Record<string, Array<string | { origin?: string }>>).testnet ?? []).map(
+                (e) => (typeof e === 'string' ? e : e?.origin),
+            );
             expect(
-                (trusted as Record<string, string[]>).testnet ?? [],
+                testnetTrusted,
                 'toolkit origin was removed from testnet trust on transient lock — Issue 3 regression',
             ).toContain('http://localhost:5172');
 

--- a/tests/e2e/wallet-onboarding.e2e.spec.ts
+++ b/tests/e2e/wallet-onboarding.e2e.spec.ts
@@ -484,6 +484,20 @@ test.describe('Wallet onboarding (real extension)', () => {
         )
         .toEqual([PUB_KEY]);
 
+      // onImport finishes with `router.navigate(['/home'])` AFTER discoverAccounts
+      // resolves — which is LATER than the vault persist we polled above. That
+      // trailing navigation races the `page.goto('#/keys')` below: when it fires
+      // last it clobbers /keys back to /home (observed flake — the failure
+      // screenshot shows the home view, not the key list). Wait for the import to
+      // settle on /home first, so our /keys navigation is the final one.
+      await expect
+        .poll(async () => await page.evaluate(() => location.hash).catch(() => ''), {
+          timeout: 30_000,
+          intervals: [200, 500],
+          message: 'import never navigated to /home',
+        })
+        .toBe('#/home');
+
       // Drive to the Key Manager. The view loads, calls
       // `getAccountsByAuthorizers` (mocked → returns tnetacct.test), then
       // renders one row per pubkey with the resolved account name. We


### PR DESCRIPTION
Four e2e specs asserted extension behavior that no longer matches the current build, so they failed regardless of the wallet branch under test (verified: identical failures on a clean web-app `origin/master` baseline).

## Root causes & fixes
- **`TRUSTED_APPS` shape change** — the wallet-attestation feature changed entries from bare origin strings to `{ origin, attestationConsentedAt? }` objects. Tests asserting `.toContain("http://localhost:5172")` got `[{origin: "..."}]`.
  - `readTrustedApps` (wallet-disconnect-connect) normalizes entries → origin strings.
  - The inline cross-env-disconnect mutation compares on `.origin` (it filtered by string identity → removed nothing → post-disconnect assertion failed).
  - `wallet-network-sync` Issue 3's inline `TRUSTED_APPS` read maps entries → origins.
- **`audit-c-n2`** demonstrated the C-N2 silent-network-takeover vuln, but the **v4 N-N1 fix removed the dapp-callable `addNetwork` handler**. Inverted the test to assert the takeover is **blocked** (addNetwork rejected, switchNetwork rejected, env not hijacked, attacker RPC never contacted).
- **`wallet-onboarding`** import test had a navigation **race**: `onImport` ends with `router.navigate(['/home'])` *after* `discoverAccounts` resolves — later than the vault-persist the test polled on — so it raced `page.goto('#/keys')` and intermittently clobbered `/keys` back to `/home` (the failure screenshot showed the home view, not the key list). Now waits for the import to settle on `/home` before navigating to the Key Manager.

## Verification (against current extension build)
- `wallet-disconnect-connect`: **7/7** ✓
- `audit-c-n2` ✓ · `wallet-network-sync` Issue 3 ✓
- `wallet-onboarding` import: **3/3** ✓ (`--repeat-each=3`; was an intermittent flake) and passes first-attempt in the full suite
- **Full suite green** — all 58 runnable specs pass (1 pre-existing `.skip`). One unrelated test (`empty-resolve` Reg 1, untouched by this PR) flaked once and recovered on retry.