### PR TITLE
fix: make round-robin actually fail over, and stop leading with an endpoint that 404s

### DIFF
--- a/src/utilities/blockchain.ts
+++ b/src/utilities/blockchain.ts
@@ -96,7 +96,19 @@ export abstract class BlockchainService {
                 requestErrors.push(err);
                 console.error(`Failed to make request because of error: ${err}`);
             }
-            if (result) return result;
+            // A raw `Response` is truthy even for 4xx/5xx, so returning it here
+            // short-circuits the round-robin on an endpoint that simply does not
+            // serve the API (e.g. test.ultra.eosusa.io 404s
+            // get_accounts_by_authorizers). Treat a non-ok Response as a failure
+            // so we advance to the next endpoint instead of giving up.
+            const isFailedHttpResponse =
+                typeof Response !== 'undefined' && result instanceof Response && !result.ok;
+            if (isFailedHttpResponse) {
+                requestErrors.push(new Error(`HTTP ${(result as Response).status} from endpoint`));
+                console.error(`Endpoint returned HTTP ${(result as Response).status}; trying next endpoint`);
+            } else if (result) {
+                return result;
+            }
             newLastApiNodeIndex++;
 
             if (newLastApiNodeIndex >= BlockchainService.maxApiRetries) newLastApiNodeIndex = 0;

--- a/src/utilities/networks.ts
+++ b/src/utilities/networks.ts
@@ -20,11 +20,15 @@ export const defaultNetworks = [
         name: 'Testnet',
         chainId: '7fc56be645bb76ab9d747b53089f132dcb7681db06f0852cfa03eaf6f7ac80e9',
         urls: [
-            'https://test.ultra.eosusa.io',
-            'https://api.ultra-testnet.cryptolions.io',
+            // Order matters: App.vue starts on urls[0].
+            // test.ultra.eosusa.io 404s get_accounts_by_authorizers (breaks
+            // Ledger login), so it must not lead. cryptolions serves it but
+            // IP-bans clients at the TCP layer under load, so it fails slowly.
             'https://api.testnet.ultra.eossweden.org',
-            'https://ultra-testnet.eosphere.io',
             'https://testnet.ultra.eosrio.io',
+            'https://ultra-testnet.eosphere.io',
+            'https://api.ultra-testnet.cryptolions.io',
+            'https://test.ultra.eosusa.io',
         ],
         isPublic: true,
     },


### PR DESCRIPTION
Two defects found by the post-sweep review — one of them breaks a live feature.

## 1. `roundRobinRequest` never fails over on HTTP errors (P0)

`blockchain.ts` advanced to the next endpoint only when the callback result was **falsy**:

```ts
result = await callback().catch(() => null);
if (result) return result;      // ← a 404 Response object is TRUTHY
```

`fetchWithTimeout` resolves with the `Response` for **any** HTTP status and only rejects on abort/network error. So a 404 returned immediately from `urls[0]` and the remaining endpoints were never tried. This silently defeated the retry pool at every call site, not just the one below.

## 2. The testnet list led with an endpoint that 404s the call it needs

`test.ultra.eosusa.io` was `urls[0]`, and it returns `{"message":"Unknown Endpoint"}` for `get_accounts_by_authorizers`. Combined with (1), Ledger login on testnet dead-ended at *"Could not get API response to obtain the list of accounts"* — with four capable endpoints sitting unused below it.

Verified live for the new leading order:

| Endpoint | `get_accounts_by_authorizers` |
|---|---|
| `api.testnet.ultra.eossweden.org` | ✅ |
| `testnet.ultra.eosrio.io` | ✅ |
| `ultra-testnet.eosphere.io` | ✅ |
| `api.ultra-testnet.cryptolions.io` | ✅ but IP-bans under load |
| `test.ultra.eosusa.io` | ❌ — now last |

Note (1) is pre-existing, not introduced by the endpoint sweep; the sweep just made it visible.