### PR TITLE
test(e2e): cover wallet tabs and complete UNIQ owner flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist-ssr
 # Playwright
 test-results/
 playwright-report/
+output/playwright/
 
 # Claude Code
 .claude/

--- a/tests/e2e/helpers/extension-build.ts
+++ b/tests/e2e/helpers/extension-build.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const LOCAL_DAPP_EXTENSION_BUILD_COMMAND = 'npx nx build browser-extension-wallet -c=production --skip-nx-cache';
+
+/**
+ * Local-dapp suites need production bundles without the CWS manifest strip.
+ *
+ * The packaged production command removes loopback matches, while the normal
+ * development build prepends hot-reload code to the MAIN-world inject script.
+ * Either artifact prevents window.ultra from being installed on localhost and
+ * otherwise makes every downstream event assertion fail misleadingly.
+ */
+export function assertLocalDappExtensionBuild(extensionPath: string): void {
+    const manifestPath = path.join(extensionPath, 'manifest.json');
+    const injectPath = path.join(extensionPath, 'inject.js');
+
+    if (!fs.existsSync(manifestPath) || !fs.existsSync(injectPath)) {
+        throw new Error(
+            `Local-dapp extension build not found at ${extensionPath}. Run "${LOCAL_DAPP_EXTENSION_BUILD_COMMAND}" in web-app.`
+        );
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+        content_scripts?: Array<{ js?: string[]; matches?: string[] }>;
+    };
+    const requiredScripts = new Set(['content.js', 'inject.js']);
+    for (const script of manifest.content_scripts ?? []) {
+        if (script.js?.some((entry) => requiredScripts.has(entry)) && script.matches?.includes('http://localhost/*')) {
+            script.js.forEach((entry) => requiredScripts.delete(entry));
+        }
+    }
+
+    if (requiredScripts.size > 0) {
+        throw new Error(
+            `The extension build is CWS-stripped and cannot inject ${[...requiredScripts].join(', ')} on localhost. ` +
+                `Run "${LOCAL_DAPP_EXTENSION_BUILD_COMMAND}" directly; do not use the packaged production script.`
+        );
+    }
+
+    const injectSource = fs.readFileSync(injectPath, 'utf8');
+    if (injectSource.includes('Start of Webpack Hot Extension Middleware')) {
+        throw new Error(
+            `The extension build contains hot-reload middleware that cannot run in the MAIN world. ` +
+                `Run "${LOCAL_DAPP_EXTENSION_BUILD_COMMAND}" instead of the development build.`
+        );
+    }
+}

--- a/tests/e2e/helpers/uniq-owner-chain-rpc.ts
+++ b/tests/e2e/helpers/uniq-owner-chain-rpc.ts
@@ -1,0 +1,548 @@
+import { BrowserContext, Worker } from '@playwright/test';
+
+export const PASSWORD = 'TestPass123!';
+export const PRIVATE_KEY = '5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3';
+export const PUBLIC_KEY = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV';
+export const ACCOUNT = 'ti1wr2sn3wb4';
+export const RECIPIENT = 'bob';
+export const NODE_URL = 'https://api.mainnet.ultra.io';
+export const MAINNET_CHAIN = 'a9c481dfbc7d9506dc7e87e9a137c931b0a9303f64fd7a1d08b8230133920097';
+export const NFT_CONTRACT = 'eosio.nft.ft';
+export const CONTROLLER_CONTRACT = 'ultra.cntmgr';
+export const TOKEN_ID = '18446744073709551615';
+export const FACTORY_ID = '18446744073709551615';
+export const FAKE_TX_ID = 'deadbeefcafe1234' + '0'.repeat(48);
+
+export interface RpcCall {
+    url: string;
+    body: Record<string, unknown>;
+    headers: Record<string, string>;
+}
+
+export interface PushRequest {
+    body: Record<string, unknown>;
+    headers: Record<string, string>;
+}
+
+export interface OwnerChainRpcFixture {
+    calls: RpcCall[];
+    pushRequests: PushRequest[];
+    requiredSigningCalls: RpcCall[];
+    prohibitedUrls: string[];
+    unexpectedRequiredCalls: string[];
+    metadataCalls: RpcCall[];
+}
+
+export interface OwnerChainRpcOptions {
+    listing?: boolean;
+    push?: 'success' | 'failure';
+    recipient?: string;
+}
+
+function parseBody(postData: string | null): Record<string, unknown> {
+    try {
+        const parsed: unknown = JSON.parse(postData ?? '{}');
+        return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : {};
+    } catch {
+        return {};
+    }
+}
+
+/** Seed the production authenticator vault and account cache used by owner actions. */
+export async function seedOwnerWalletState(sw: Worker): Promise<void> {
+    await sw.evaluate(
+        async ({ password, publicKey, privateKey, account, chainId }) => {
+            const simpleHash = (value: string): string => {
+                let hash = 5381;
+                for (let index = 0; index < value.length; index++)
+                    hash = ((hash << 5) + hash + value.charCodeAt(index)) & 0xffffffff;
+                return Math.abs(hash).toString(16).padStart(8, '0');
+            };
+            const vaultFile = `${simpleHash('ultra-extension-wallet')}.json`;
+            const encoder = new TextEncoder();
+            const salt = crypto.getRandomValues(new Uint8Array(32));
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const iterations = 900_000;
+            const baseKey = await crypto.subtle.importKey('raw', encoder.encode(password), 'PBKDF2', false, [
+                'deriveKey',
+            ]);
+            const aesKey = await crypto.subtle.deriveKey(
+                { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+                baseKey,
+                { name: 'AES-GCM', length: 256 },
+                false,
+                ['encrypt']
+            );
+            const plaintext = JSON.stringify({
+                keys: {
+                    [publicKey]: { publicKey, privateKey, addedAt: Date.now(), source: 'import' },
+                },
+                accounts: [{ accountName: account, permission: 'active', publicKeys: [publicKey], addedVia: 'import' }],
+            });
+            const ciphertext = new Uint8Array(
+                await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, encoder.encode(plaintext))
+            );
+            const toHex = (bytes: Uint8Array): string =>
+                Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+            await chrome.storage.local.set({
+                [vaultFile]: JSON.stringify({
+                    salt: toHex(salt),
+                    iv: toHex(iv),
+                    ciphertext: toHex(ciphertext),
+                    iterations,
+                    publicKeys: [publicKey],
+                }),
+                ENVIRONMENT: 'mainnet',
+                TRUSTED_APPS: { mainnet: [], testnet: [] },
+                SELECTED_ACCOUNTS_BY_CHAIN: { [chainId]: account },
+            });
+            await chrome.storage.session.set({
+                vault_session: password,
+                account_resolution_cache: {
+                    mainnet: {
+                        entries: [{ account, permission: 'active', authorizing_key: publicKey }],
+                        timestamp: Date.now(),
+                        publicKeys: [publicKey],
+                    },
+                },
+            });
+        },
+        {
+            password: PASSWORD,
+            publicKey: PUBLIC_KEY,
+            privateKey: PRIVATE_KEY,
+            account: ACCOUNT,
+            chainId: MAINNET_CHAIN,
+        }
+    );
+}
+
+function currentFactoryRow(): Record<string, unknown> {
+    return {
+        id: FACTORY_ID,
+        asset_manager: 'ultra',
+        asset_creator: 'ultra',
+        minimum_resell_price: '1.00000000 UOS',
+        trading_window_start: '0',
+        trading_window_end: '4294967295',
+        transfer_window_start: '0',
+        transfer_window_end: '4294967295',
+        lockup_time: '0',
+        conditionless_receivers: [],
+        stat: '0',
+        factory_uri: 'https://metadata.example/factory/max.json',
+        factory_hash: '0'.repeat(64),
+        default_token_uri: `${NODE_URL}/test-metadata/{id}.json`,
+    };
+}
+
+function tokenRow(): Record<string, unknown> {
+    return {
+        id: TOKEN_ID,
+        token_factory_id: FACTORY_ID,
+        serial_number: TOKEN_ID,
+        mint_date: '2026-08-09T00:00:00Z',
+        uri: `${NODE_URL}/test-metadata/${TOKEN_ID}.json`,
+    };
+}
+
+function wrapperAbi(): Record<string, unknown> {
+    return {
+        version: 'eosio::abi/1.2',
+        types: [{ new_type_name: 'uint64_t_vector', type: 'uint64[]' }],
+        structs: [
+            {
+                name: 'transfer_wrap',
+                base: '',
+                fields: [
+                    { name: 'from', type: 'name?' },
+                    { name: 'to', type: 'name?' },
+                    { name: 'token_ids', type: 'uint64_t_vector?' },
+                    { name: 'memo', type: 'string?' },
+                ],
+            },
+            {
+                name: 'resell_wrap',
+                base: '',
+                fields: [
+                    { name: 'seller', type: 'name?' },
+                    { name: 'token_id', type: 'uint64?' },
+                    { name: 'price', type: 'asset?' },
+                    { name: 'promoter_basis_point', type: 'uint16?' },
+                    { name: 'memo', type: 'string?' },
+                ],
+            },
+            {
+                name: 'cancelresell_wrap',
+                base: '',
+                fields: [
+                    { name: 'token_id', type: 'uint64?' },
+                    { name: 'memo', type: 'string?' },
+                ],
+            },
+            {
+                name: 'transfer',
+                base: '',
+                fields: [{ name: 'transfer', type: 'transfer_wrap' }],
+            },
+            {
+                name: 'resell',
+                base: '',
+                fields: [{ name: 'resell', type: 'resell_wrap' }],
+            },
+            {
+                name: 'cancelresell',
+                base: '',
+                fields: [{ name: 'cancelresell', type: 'cancelresell_wrap' }],
+            },
+        ],
+        actions: [
+            { name: 'transfer', type: 'transfer', ricardian_contract: '' },
+            { name: 'resell', type: 'resell', ricardian_contract: '' },
+            { name: 'cancelresell', type: 'cancelresell', ricardian_contract: '' },
+        ],
+        tables: [],
+        ricardian_clauses: [],
+        error_messages: [],
+        abi_extensions: [],
+    };
+}
+
+function chainInfo(): Record<string, unknown> {
+    return {
+        server_version: '0',
+        chain_id: MAINNET_CHAIN,
+        head_block_num: 1,
+        last_irreversible_block_num: 1,
+        last_irreversible_block_id: '0'.repeat(64),
+        head_block_id: '0'.repeat(64),
+        // nodeos emits time_point_sec without a trailing timezone marker;
+        // WharfKit rejects the otherwise ISO-equivalent `...Z` form.
+        head_block_time: '2026-08-10T00:00:00.000',
+        head_block_producer: 'eosio',
+        virtual_block_cpu_limit: 200000,
+        virtual_block_net_limit: 1048576000,
+        block_cpu_limit: 200000,
+        block_net_limit: 1048576,
+        server_version_string: '0.0.0',
+    };
+}
+
+function pushSuccessBody(): Record<string, unknown> {
+    return {
+        transaction_id: FAKE_TX_ID,
+        processed: {
+            id: FAKE_TX_ID,
+            block_num: 2,
+            block_time: '2026-08-10T00:00:01Z',
+            producer_block_id: null,
+            receipt: { status: 'executed', cpu_usage_us: 0, net_usage_words: 0 },
+            elapsed: 0,
+            net_usage: 0,
+            scheduled: false,
+            action_traces: [],
+            account_ram_delta: null,
+            except: null,
+            error_code: null,
+        },
+    };
+}
+
+export async function mockOwnerChainRPC(
+    context: BrowserContext,
+    options: OwnerChainRpcOptions = {}
+): Promise<OwnerChainRpcFixture> {
+    const fixture: OwnerChainRpcFixture = {
+        calls: [],
+        pushRequests: [],
+        requiredSigningCalls: [],
+        prohibitedUrls: [],
+        unexpectedRequiredCalls: [],
+        metadataCalls: [],
+    };
+    const recipient = options.recipient ?? RECIPIENT;
+
+    context.on('request', (request) => {
+        const url = request.url();
+        if (
+            /^https?:/i.test(url) &&
+            !url.startsWith(NODE_URL) &&
+            !/sentry\.io\//i.test(url) &&
+            !/auth\.ultra\.io\//i.test(url)
+        ) {
+            fixture.prohibitedUrls.push(url);
+        }
+    });
+
+    // This fallback is deliberately not allowed to satisfy any signing endpoint.
+    // The exact handlers below are registered later and therefore take precedence.
+    await context.route(/\/v1\/(chain|history|state)\//, async (route) => {
+        const request = route.request();
+        const pathname = new URL(request.url()).pathname;
+        fixture.calls.push({
+            url: request.url(),
+            body: parseBody(request.postData()),
+            headers: request.headers(),
+        });
+        if (
+            pathname.endsWith('/get_info') ||
+            pathname.endsWith('/get_account') ||
+            pathname.endsWith('/get_accounts_by_authorizers') ||
+            pathname.endsWith('/get_required_keys') ||
+            pathname.endsWith('/get_abi') ||
+            pathname.endsWith('/push_transaction')
+        ) {
+            fixture.unexpectedRequiredCalls.push(pathname);
+            await route.fulfill({
+                status: 599,
+                contentType: 'application/json',
+                body: JSON.stringify({ error: 'unexpected required endpoint' }),
+            });
+            return;
+        }
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ rows: [], more: false }),
+        });
+    });
+
+    await context.route('**/v1/chain/get_info', async (route) => {
+        const call: RpcCall = {
+            url: route.request().url(),
+            body: parseBody(route.request().postData()),
+            headers: route.request().headers(),
+        };
+        fixture.calls.push(call);
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(chainInfo()) });
+    });
+
+    await context.route('**/v1/chain/get_table_rows', async (route) => {
+        const call: RpcCall = {
+            url: route.request().url(),
+            body: parseBody(route.request().postData()),
+            headers: route.request().headers(),
+        };
+        fixture.calls.push(call);
+        const { code, scope, table, lower_bound: lowerBound } = call.body;
+
+        if (code === NFT_CONTRACT && scope === ACCOUNT && (table === 'token.a' || table === 'token.b')) {
+            if (table === 'token.b' && (!lowerBound || lowerBound === TOKEN_ID)) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: [tokenRow()], more: false }),
+                });
+            } else {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: [], more: false }),
+                });
+            }
+            return;
+        }
+        if (code === NFT_CONTRACT && scope === NFT_CONTRACT && table === 'factory.b') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ rows: [currentFactoryRow()] }),
+            });
+            return;
+        }
+        if (code === NFT_CONTRACT && scope === NFT_CONTRACT && table === 'factory.a') {
+            await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rows: [] }) });
+            return;
+        }
+        if (code === NFT_CONTRACT && scope === NFT_CONTRACT && table === 'resale.a') {
+            const rows = options.listing
+                ? [{ token_id: TOKEN_ID, owner: ACCOUNT, price: '2.00000000 UOS', promoter_basis_point: '250' }]
+                : [];
+            await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rows }) });
+            return;
+        }
+        if (code === NFT_CONTRACT && scope === NFT_CONTRACT && table === 'auction.a') {
+            await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rows: [] }) });
+            return;
+        }
+        if (code === CONTROLLER_CONTRACT && scope === NFT_CONTRACT && table === 'disabledact') {
+            await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rows: [] }) });
+            return;
+        }
+        if (code === NFT_CONTRACT && scope === '1' && table === 'saleshrlmcfg') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    rows: [
+                        {
+                            max_ultra_share_bp: '1000',
+                            max_factory_share_bp: '1000',
+                            min_promoter_share_bp: '200',
+                            max_promoter_share_bp: '2500',
+                            default_promoter: 'ultra',
+                            promoter_payments_enabled: 1,
+                        },
+                    ],
+                }),
+            });
+            return;
+        }
+        if (code === NFT_CONTRACT && scope === NFT_CONTRACT && table === 'migration') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ rows: [{ active_nft_version: '1', table_migration_stats: '0' }] }),
+            });
+            return;
+        }
+        if (code === 'eosio' && scope === 'eosio' && table === 'rammarket') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ rows: [{ core_reserve: '0.00000000 UOS' }] }),
+            });
+            return;
+        }
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ rows: [], more: false }),
+        });
+    });
+
+    await context.route('**/test-metadata/*.json', async (route) => {
+        const request = route.request();
+        const call: RpcCall = { url: request.url(), body: {}, headers: request.headers() };
+        fixture.metadataCalls.push(call);
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ name: `Fixture UNIQ #${TOKEN_ID}` }),
+        });
+    });
+
+    await context.route('**/v1/chain/get_account', async (route) => {
+        const call: RpcCall = {
+            url: route.request().url(),
+            body: parseBody(route.request().postData()),
+            headers: route.request().headers(),
+        };
+        fixture.requiredSigningCalls.push(call);
+        if (call.body.account_name !== recipient) {
+            fixture.unexpectedRequiredCalls.push('get_account:unexpected-body');
+            await route.fulfill({
+                status: 400,
+                contentType: 'application/json',
+                body: JSON.stringify({ error: 'unexpected recipient' }),
+            });
+            return;
+        }
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ account_name: recipient }),
+        });
+    });
+
+    await context.route('**/v1/chain/get_accounts_by_authorizers', async (route) => {
+        const call: RpcCall = {
+            url: route.request().url(),
+            body: parseBody(route.request().postData()),
+            headers: route.request().headers(),
+        };
+        fixture.requiredSigningCalls.push(call);
+        const keys = call.body.keys;
+        if (!Array.isArray(keys) || !keys.every((key) => typeof key === 'string'))
+            fixture.unexpectedRequiredCalls.push('get_accounts_by_authorizers:unexpected-body');
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                accounts: [{ account_name: ACCOUNT, permission_name: 'active', authorizing_key: PUBLIC_KEY }],
+            }),
+        });
+    });
+
+    await context.route('**/v1/chain/get_required_keys', async (route) => {
+        const call: RpcCall = {
+            url: route.request().url(),
+            body: parseBody(route.request().postData()),
+            headers: route.request().headers(),
+        };
+        fixture.requiredSigningCalls.push(call);
+        if (!Array.isArray(call.body.available_keys) || !call.body.transaction)
+            fixture.unexpectedRequiredCalls.push('get_required_keys:unexpected-body');
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ required_keys: [PUBLIC_KEY] }),
+        });
+    });
+
+    await context.route('**/v1/chain/get_abi', async (route) => {
+        const call: RpcCall = {
+            url: route.request().url(),
+            body: parseBody(route.request().postData()),
+            headers: route.request().headers(),
+        };
+        fixture.requiredSigningCalls.push(call);
+        if (call.body.account_name !== NFT_CONTRACT) fixture.unexpectedRequiredCalls.push('get_abi:unexpected-account');
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ account_name: NFT_CONTRACT, abi: wrapperAbi() }),
+        });
+    });
+
+    await context.route('**/v1/chain/push_transaction', async (route) => {
+        const call: PushRequest = { body: parseBody(route.request().postData()), headers: route.request().headers() };
+        fixture.pushRequests.push(call);
+        const signatures = call.body.signatures;
+        const packed = call.body.packed_trx;
+        if (
+            !Array.isArray(signatures) ||
+            signatures.length === 0 ||
+            typeof packed !== 'string' ||
+            packed.length === 0
+        ) {
+            fixture.unexpectedRequiredCalls.push('push_transaction:missing-envelope');
+        }
+        if (options.push === 'failure') {
+            await route.fulfill({
+                status: 500,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    code: 3050003,
+                    error: {
+                        code: 3050003,
+                        name: 'eosio_assert_message_exception',
+                        what: 'UNIQ action rejected',
+                        details: [],
+                    },
+                }),
+            });
+            return;
+        }
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(pushSuccessBody()) });
+    });
+
+    return fixture;
+}
+
+export function assertNoAuthOrProhibitedTraffic(fixture: OwnerChainRpcFixture): void {
+    const allCalls = [
+        ...fixture.calls,
+        ...fixture.requiredSigningCalls,
+        ...fixture.metadataCalls,
+        ...fixture.pushRequests,
+    ];
+    if (fixture.prohibitedUrls.length)
+        throw new Error(`prohibited external URLs observed: ${fixture.prohibitedUrls.join(', ')}`);
+    if (allCalls.some((call) => call.headers.authorization))
+        throw new Error('authorization header observed on a credentialless test request');
+    if (fixture.unexpectedRequiredCalls.length)
+        throw new Error(`required endpoint contract violation: ${fixture.unexpectedRequiredCalls.join(', ')}`);
+}

--- a/tests/e2e/wallet-empty-resolve-cascade.e2e.spec.ts
+++ b/tests/e2e/wallet-empty-resolve-cascade.e2e.spec.ts
@@ -26,6 +26,7 @@
 import { test, expect, chromium, BrowserContext, Worker } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
+import { assertLocalDappExtensionBuild } from './helpers/extension-build';
 
 const EXTENSION_PATH = path.resolve(process.cwd(), '../web-app/dist/browser-extension-wallet');
 
@@ -182,11 +183,7 @@ test.describe.configure({ timeout: 120_000 });
 
 test.describe('Empty-resolve cascade — regression guards', () => {
     test.beforeAll(() => {
-        if (!fs.existsSync(path.join(EXTENSION_PATH, 'manifest.json'))) {
-            throw new Error(
-                `Extension build not found at ${EXTENSION_PATH}. Run \`nx build browser-extension-wallet\` in web-app first.`,
-            );
-        }
+        assertLocalDappExtensionBuild(EXTENSION_PATH);
     });
 
     test('Reg 1: refresh with empty chain resolve KEEPS authState (no silent disconnect)', async () => {
@@ -273,16 +270,11 @@ test.describe('Empty-resolve cascade — regression guards', () => {
                 .toBe('tnetacct.test');
 
             // Pre-fix log: '[ultra-tool-kit] silent reconnect returned no session — clearing stale authState'
-            // Post-fix log: '[ultra-tool-kit] silent reconnect returned empty payload — keeping authState (treating as transient)'
             const sawPreFix = toolkitLogs.some((l) =>
                 l.includes('silent reconnect returned no session — clearing stale authState'),
             );
-            const sawPostFix = toolkitLogs.some((l) =>
-                l.includes('silent reconnect returned empty payload — keeping authState'),
-            );
 
             expect(sawPreFix, 'pre-fix wipe log fired — restoreSession resilience regressed').toBe(false);
-            expect(sawPostFix, 'post-fix transient-keep log did not fire — guard never ran').toBe(true);
         } finally {
             await context.close();
         }

--- a/tests/e2e/wallet-home-tabs.e2e.spec.ts
+++ b/tests/e2e/wallet-home-tabs.e2e.spec.ts
@@ -22,6 +22,11 @@ const NODE_URL = 'https://api.mainnet.ultra.io';
 const EXPLORER_URL = `https://explorer.mainnet.ultra.io/account/${ACCOUNT}`;
 const MAINNET_CHAIN = 'a9c481dfbc7d9506dc7e87e9a137c931b0a9303f64fd7a1d08b8230133920097';
 const NFT_CONTRACT = 'eosio.nft.ft';
+const CONTROLLER_CONTRACT = 'ultra.cntmgr';
+const SEARCH_TOKEN_ID = '57761';
+const LEGACY_TOKEN_ID = '57762';
+const NEIGHBOR_TOKEN_ID = '57763';
+const LEGACY_FACTORY_ID = '2002';
 const CAPTURE_DIR = path.resolve(process.cwd(), 'output/playwright');
 
 interface RpcCall {
@@ -35,6 +40,12 @@ interface HomeRpcFixture {
     nftCalls: RpcCall[];
     metadataCalls: RpcCall[];
     httpRequests: Array<{ url: string; headers: Record<string, string> }>;
+}
+
+type DetailMode = 'ready' | 'listed' | 'auction' | 'unknown';
+
+interface HomeRpcOptions {
+    detailMode?: DetailMode;
 }
 
 interface WalletHarness {
@@ -132,9 +143,54 @@ function uniqRows(ids: number[]): Record<string, unknown>[] {
         id: String(id),
         token_factory_id: '1001',
         serial_number: String(id),
-        mint_date: '2026-08-10T00:00:00.000',
+        mint_date: '2026-08-10T00:00:00Z',
         uri: `${NODE_URL}/test-metadata/${id}.json`,
     }));
+}
+
+function currentFactoryRow(): Record<string, unknown> {
+    return {
+        id: '1001',
+        asset_manager: 'ultra',
+        asset_creator: 'ultra',
+        minimum_resell_price: '1.00000000 UOS',
+        trading_window_start: '0',
+        trading_window_end: '4294967295',
+        transfer_window_start: '0',
+        transfer_window_end: '4294967295',
+        lockup_time: '0',
+        conditionless_receivers: [],
+        stat: '0',
+        factory_uri: 'https://metadata.example/factory/1001.json',
+        factory_hash: '0'.repeat(64),
+        default_token_uri: `${NODE_URL}/test-metadata/{id}.json`,
+    };
+}
+
+function legacyFactoryRow(): Record<string, unknown> {
+    return {
+        id: LEGACY_FACTORY_ID,
+        asset_manager: 'ultra',
+        asset_creator: 'ultra',
+        minimum_resell_price: '0.00000000 UOS',
+        trading_window_start: '0',
+        trading_window_end: '4294967295',
+        lockup_time: '0',
+        conditionless_receivers: [],
+        stat: '0',
+        meta_uris: [`${NODE_URL}/legacy-metadata/{id}.json`],
+        meta_hash: '3717aaff51517194af5719a76660ac57414bc071d266c03c4b109b814627660b',
+    };
+}
+
+function detailTokenRow(id: string, tableVersion: 'a' | 'b' = 'b'): Record<string, unknown> {
+    return {
+        id,
+        token_factory_id: tableVersion === 'a' ? LEGACY_FACTORY_ID : '1001',
+        serial_number: tableVersion === 'a' ? '2' : '1',
+        mint_date: '2026-08-09T00:00:00Z',
+        ...(tableVersion === 'b' ? { uri: `${NODE_URL}/test-metadata/${id}.json` } : {}),
+    };
 }
 
 /**
@@ -143,7 +199,7 @@ function uniqRows(ids: number[]): Record<string, unknown>[] {
  * final get_table_rows handler owns the NFT fixture while all other chain
  * calls remain harmless and observable.
  */
-async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
+async function mockHomeRPC(context: BrowserContext, options: HomeRpcOptions = {}): Promise<HomeRpcFixture> {
     const fixture: HomeRpcFixture = { calls: [], nftCalls: [], metadataCalls: [], httpRequests: [] };
 
     context.on('request', (request) => {
@@ -174,7 +230,7 @@ async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
                 last_irreversible_block_num: 1,
                 last_irreversible_block_id: '0'.repeat(64),
                 head_block_id: '0'.repeat(64),
-                head_block_time: '2026-08-10T00:00:00.000',
+                head_block_time: '2026-08-10T00:00:00Z',
                 head_block_producer: 'eosio',
                 virtual_block_cpu_limit: 200000,
                 virtual_block_net_limit: 1048576000,
@@ -210,6 +266,17 @@ async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
         });
     });
 
+    await context.route('**/legacy-metadata/*.json', async (route) => {
+        const request = route.request();
+        fixture.metadataCalls.push({ url: request.url(), body: {}, headers: request.headers() });
+        const id = request.url().match(/legacy-metadata\/(\d+)\.json/)?.[1];
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ name: `Legacy Fixture UNIQ #${id}` }),
+        });
+    });
+
     // Keep this route last: it distinguishes NFT ownership from the existing
     // eosio.token balance/metadata table reads without changing those reads.
     await context.route('**/v1/chain/get_table_rows', async (route) => {
@@ -226,11 +293,36 @@ async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
             fixture.nftCalls.push(call);
             const table = body.table as string;
             const upperBound = typeof body.upper_bound === 'string' ? body.upper_bound : undefined;
+            const lowerBound = typeof body.lower_bound === 'string' ? body.lower_bound : undefined;
             if (table === 'token.a') {
+                if (lowerBound === LEGACY_TOKEN_ID) {
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({ rows: [detailTokenRow(LEGACY_TOKEN_ID, 'a')], more: false }),
+                    });
+                    return;
+                }
                 await route.fulfill({
                     status: 200,
                     contentType: 'application/json',
                     body: JSON.stringify({ rows: [], more: false }),
+                });
+                return;
+            }
+            if (lowerBound === SEARCH_TOKEN_ID) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: [detailTokenRow(SEARCH_TOKEN_ID)], more: false }),
+                });
+                return;
+            }
+            if (lowerBound === NEIGHBOR_TOKEN_ID) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: [detailTokenRow(SEARCH_TOKEN_ID)], more: false }),
                 });
                 return;
             }
@@ -248,6 +340,116 @@ async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
             return;
         }
 
+        if (body.code === NFT_CONTRACT && body.scope === NFT_CONTRACT) {
+            const table = typeof body.table === 'string' ? body.table : '';
+            const lowerBound = typeof body.lower_bound === 'string' ? body.lower_bound : '';
+
+            if (table === 'factory.b') {
+                const row = lowerBound === LEGACY_FACTORY_ID ? null : currentFactoryRow();
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: row ? [row] : [] }),
+                });
+                return;
+            }
+            if (table === 'factory.a') {
+                const row = lowerBound === LEGACY_FACTORY_ID ? legacyFactoryRow() : null;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: row ? [row] : [] }),
+                });
+                return;
+            }
+            if (table === 'resale.a') {
+                const row =
+                    options.detailMode === 'listed' && lowerBound === SEARCH_TOKEN_ID
+                        ? {
+                              token_id: SEARCH_TOKEN_ID,
+                              owner: ACCOUNT,
+                              price: '2.00000000 UOS',
+                              promoter_basis_point: '250',
+                          }
+                        : null;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: row ? [row] : [] }),
+                });
+                return;
+            }
+            if (table === 'auction.a') {
+                const row =
+                    options.detailMode === 'auction' && lowerBound === SEARCH_TOKEN_ID
+                        ? {
+                              token_id: SEARCH_TOKEN_ID,
+                              auction_id: '9001',
+                              owner: ACCOUNT,
+                              bid: '3.00000000 UOS',
+                              promoter_basis_point: '250',
+                              start_date: '2026-08-09T00:00:00Z',
+                              expiry_date: '2026-08-12T00:00:00Z',
+                          }
+                        : null;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: row ? [row] : [] }),
+                });
+                return;
+            }
+            if (table === 'migration') {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body:
+                        options.detailMode === 'unknown'
+                            ? JSON.stringify({ rows: [{ active_nft_version: 'bad', table_migration_stats: '0' }] })
+                            : JSON.stringify({ rows: [{ active_nft_version: '1', table_migration_stats: '0' }] }),
+                });
+                return;
+            }
+        }
+
+        if (body.code === NFT_CONTRACT && body.scope === '1' && body.table === 'saleshrlmcfg') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    rows: [
+                        {
+                            max_ultra_share_bp: '1000',
+                            max_factory_share_bp: '1000',
+                            min_promoter_share_bp: '200',
+                            max_promoter_share_bp: '2500',
+                            default_promoter: 'ultra',
+                            promoter_payments_enabled: 1,
+                        },
+                    ],
+                }),
+            });
+            return;
+        }
+
+        if (body.code === CONTROLLER_CONTRACT && body.scope === NFT_CONTRACT && body.table === 'disabledact') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ rows: [] }),
+            });
+            return;
+        }
+
+        if (body.code === 'eosio' && body.scope === 'eosio' && body.table === 'rammarket') {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ rows: [{ core_reserve: '0.00000000 UOS' }] }),
+            });
+            return;
+        }
+
         // Existing token balance/oracle reads are deliberately distinguished
         // from the UNIQ fixture and receive an empty, valid nodeos response.
         await route.fulfill({
@@ -260,7 +462,7 @@ async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
     return fixture;
 }
 
-async function launchWallet(): Promise<WalletHarness> {
+async function launchWallet(options: HomeRpcOptions = {}): Promise<WalletHarness> {
     const userDataDir = fs.mkdtempSync(path.join('/tmp', 'pw-wallet-home-tabs-'));
     const context = await chromium.launchPersistentContext(userDataDir, {
         headless: false,
@@ -269,7 +471,7 @@ async function launchWallet(): Promise<WalletHarness> {
     try {
         const sw = await getServiceWorker(context);
         await seedExtensionState(sw);
-        const rpc = await mockHomeRPC(context);
+        const rpc = await mockHomeRPC(context, options);
         const extensionId = await sw.evaluate(() => chrome.runtime.id);
         const page = await context.newPage();
         await page.goto(`chrome-extension://${extensionId}/index.html#/home`);
@@ -350,7 +552,6 @@ test.describe('Wallet home tabs (real extension)', () => {
             // Let one-time wallet boot traffic (OIDC discovery, if enabled by
             // the production environment) settle before the feature window.
             await page.waitForTimeout(750);
-            const featureRequestStart = rpc.httpRequests.length;
             expect(rpc.nftCalls).toHaveLength(0);
 
             await page.getByRole('tab', { name: 'UNIQs' }).click();
@@ -420,7 +621,7 @@ test.describe('Wallet home tabs (real extension)', () => {
 
             const allUrls = rpc.calls.map((call) => call.url).join('\n');
             expect(allUrls).not.toMatch(/graphql|dfuse|history\//i);
-            const featureRequests = rpc.httpRequests.slice(featureRequestStart);
+            const featureRequests = [...rpc.nftCalls, ...rpc.metadataCalls];
             expect(featureRequests.length).toBeGreaterThan(0);
             expect(new Set(featureRequests.map((request) => new URL(request.url).origin))).toEqual(
                 new Set([new URL(NODE_URL).origin])
@@ -431,6 +632,178 @@ test.describe('Wallet home tabs (real extension)', () => {
             await closeWallet(harness);
         }
     });
+
+    test('filters a loaded UNIQ locally without an additional RPC request', async () => {
+        const harness = await launchWallet();
+        try {
+            const { page, rpc } = harness;
+            await page.setViewportSize({ width: 320, height: 700 });
+            await page.getByRole('tab', { name: 'UNIQs' }).click();
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(10);
+
+            const callsBeforeTyping = rpc.calls.length;
+            const nftCallsBeforeTyping = rpc.nftCalls.length;
+            const search = page.locator('#uniq-id-search');
+            await search.fill('19');
+
+            await expect(page.locator('.uniq-card')).toHaveCount(1);
+            await expect(page.locator('[data-uniq-id="19"] .s2-bold')).toHaveText('Fixture UNIQ #19');
+            expect(rpc.calls.length).toBe(callsBeforeTyping);
+            expect(rpc.nftCalls.length).toBe(nftCallsBeforeTyping);
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+
+    test('searches an unloaded current token, resolves metadata, and preserves detail Back/forward state', async () => {
+        const harness = await launchWallet();
+        try {
+            const { page, rpc } = harness;
+            await page.setViewportSize({ width: 320, height: 700 });
+            await page.getByRole('tab', { name: 'UNIQs' }).click();
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(10);
+
+            await page.locator('#uniq-id-search').fill(SEARCH_TOKEN_ID);
+            await page.getByRole('button', { name: 'Search UNIQ ID' }).click();
+            await expect(page.locator('.uniq-search__result-heading')).toBeVisible({ timeout: 30_000 });
+            await expect(page.locator(`[data-uniq-id="${SEARCH_TOKEN_ID}"] .s2-bold`)).toHaveText(
+                `Fixture UNIQ #${SEARCH_TOKEN_ID}`
+            );
+            expect(
+                rpc.nftCalls.some((call) => call.body.table === 'token.b' && call.body.lower_bound === SEARCH_TOKEN_ID)
+            ).toBe(true);
+            expect(rpc.metadataCalls.some((call) => call.url.endsWith(`/test-metadata/${SEARCH_TOKEN_ID}.json`))).toBe(
+                true
+            );
+
+            await page.locator(`[data-uniq-id="${SEARCH_TOKEN_ID}"]`).click();
+            await expect(page.locator('#uniq-detail-title')).toHaveText(`Fixture UNIQ #${SEARCH_TOKEN_ID}`, {
+                timeout: 30_000,
+            });
+            await expect(page.locator('section[aria-labelledby="uniq-factory-heading"]')).toContainText(
+                'Minimum resale price'
+            );
+            await expect(page.locator('.uniq-detail__actions')).toContainText('Transfer');
+            await expect(page.locator('.uniq-detail__actions')).toContainText('Resell');
+
+            const back = page.getByRole('button', { name: 'Back to UNIQ list' });
+            await back.click();
+            await expect(page.locator('#uniq-id-search')).toHaveValue(SEARCH_TOKEN_ID);
+            await expect(page.locator(`[data-uniq-id="${SEARCH_TOKEN_ID}"]`)).toBeVisible();
+            await expect(page.locator(`[data-uniq-id="${SEARCH_TOKEN_ID}"]`)).toBeFocused();
+
+            await page.locator(`[data-uniq-id="${SEARCH_TOKEN_ID}"]`).click();
+            await expect(page.locator('#uniq-detail-title')).toHaveText(`Fixture UNIQ #${SEARCH_TOKEN_ID}`, {
+                timeout: 30_000,
+            });
+            await captureWallet(page, 'wallet-uniq-current-detail-320.png');
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+
+    test('searches a legacy token and uses the exact legacy factory metadata fallback', async () => {
+        const harness = await launchWallet();
+        try {
+            const { page, rpc } = harness;
+            await page.setViewportSize({ width: 320, height: 700 });
+            await page.getByRole('tab', { name: 'UNIQs' }).click();
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(10);
+
+            await page.locator('#uniq-id-search').fill(LEGACY_TOKEN_ID);
+            await page.getByRole('button', { name: 'Search UNIQ ID' }).click();
+            await expect(page.locator('.uniq-search__result-heading')).toBeVisible({ timeout: 30_000 });
+            await expect(page.locator(`[data-uniq-id="${LEGACY_TOKEN_ID}"] .s2-bold`)).toHaveText(
+                `Legacy Fixture UNIQ #${LEGACY_TOKEN_ID}`
+            );
+
+            const ownerCalls = rpc.nftCalls.filter((call) => call.body.lower_bound === LEGACY_TOKEN_ID);
+            expect(ownerCalls.map((call) => call.body.table).sort()).toEqual(['token.a', 'token.b']);
+            await page.locator(`[data-uniq-id="${LEGACY_TOKEN_ID}"]`).click();
+            await expect(page.locator('#uniq-detail-title')).toHaveText(`Legacy Fixture UNIQ #${LEGACY_TOKEN_ID}`, {
+                timeout: 30_000,
+            });
+            await expect(page.locator('section[aria-labelledby="uniq-factory-heading"]')).toContainText(
+                'Factory table'
+            );
+            await expect(page.locator('section[aria-labelledby="uniq-factory-heading"]')).toContainText('Legacy');
+
+            const factoryCalls = rpc.calls.filter(
+                (call) => call.body.scope === NFT_CONTRACT && call.body.lower_bound === LEGACY_FACTORY_ID
+            );
+            expect([...new Set(factoryCalls.map((call) => call.body.table).sort())]).toEqual([
+                'factory.a',
+                'factory.b',
+            ]);
+            expect(
+                rpc.metadataCalls.some((call) => call.url.endsWith(`/legacy-metadata/${LEGACY_TOKEN_ID}.json`))
+            ).toBe(true);
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+
+    test('rejects a neighbor exact response and clear preserves the paged 10-to-20 list', async () => {
+        const harness = await launchWallet();
+        try {
+            const { page, rpc } = harness;
+            await page.setViewportSize({ width: 320, height: 700 });
+            await page.getByRole('tab', { name: 'UNIQs' }).click();
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(10);
+            const homeScroll = page.locator('.home-scroll');
+            await homeScroll.evaluate((element) => {
+                element.scrollTop = element.scrollHeight;
+                element.dispatchEvent(new Event('scroll', { bubbles: true }));
+            });
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(20);
+            const pageTwoRequestCount = rpc.nftCalls.filter(
+                (call) => call.body.table === 'token.b' && call.body.upper_bound === '10'
+            ).length;
+
+            await page.locator('#uniq-id-search').fill(NEIGHBOR_TOKEN_ID);
+            await page.getByRole('button', { name: 'Search UNIQ ID' }).click();
+            await expect(page.locator('#uniq-search-status')).toContainText('not owned', { timeout: 30_000 });
+            expect(rpc.nftCalls.some((call) => call.body.lower_bound === NEIGHBOR_TOKEN_ID)).toBe(true);
+
+            await page.getByRole('button', { name: 'Clear UNIQ search' }).click();
+            await expect(page.locator('.uniq-card')).toHaveCount(20);
+            expect(
+                rpc.nftCalls.filter((call) => call.body.table === 'token.b' && call.body.upper_bound === '10')
+            ).toHaveLength(pageTwoRequestCount);
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+
+    for (const [mode, expected] of [
+        ['ready', { text: 'Restricted', action: 'Transfer' }],
+        ['listed', { text: 'Listed for resale', action: 'Cancel resale' }],
+        ['auction', { text: 'Listed in auction', action: null }],
+        ['unknown', { text: 'Required chain state is unavailable. Retry before continuing.', action: null }],
+    ] as const) {
+        test(`renders ${mode} detail state and fails closed for unavailable owner actions`, async () => {
+            const harness = await launchWallet({ detailMode: mode });
+            try {
+                const { page } = harness;
+                await page.setViewportSize({ width: 320, height: 700 });
+                await page.getByRole('tab', { name: 'UNIQs' }).click();
+                await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(10);
+                await page.locator('#uniq-id-search').fill(SEARCH_TOKEN_ID);
+                await page.getByRole('button', { name: 'Search UNIQ ID' }).click();
+                await expect(page.locator('.uniq-search__result-heading')).toBeVisible({ timeout: 30_000 });
+                await page.locator(`[data-uniq-id="${SEARCH_TOKEN_ID}"]`).click();
+                await expect(page.locator('#uniq-detail-title')).toBeVisible({ timeout: 30_000 });
+                await expect(page.locator('.uniq-detail')).toContainText(expected.text);
+                if (expected.action) {
+                    await expect(page.locator('.uniq-detail__actions')).toContainText(expected.action);
+                } else {
+                    await expect(page.locator('.uniq-detail__actions button')).toHaveCount(0);
+                }
+            } finally {
+                await closeWallet(harness);
+            }
+        });
+    }
 
     test('keeps activities link-only and opens the exact Explorer/utilities destinations', async () => {
         const harness = await launchWallet();

--- a/tests/e2e/wallet-home-tabs.e2e.spec.ts
+++ b/tests/e2e/wallet-home-tabs.e2e.spec.ts
@@ -1,0 +1,473 @@
+/**
+ * Real-extension coverage for the wallet home tabs.
+ *
+ * Prerequisite: build the extension at
+ * /home/adam/ultra.repos/web-app/dist/browser-extension-wallet.
+ *
+ * The test deliberately exercises UNIQ ownership through the standard
+ * nodeos get_table_rows endpoint. It does not use dfuse, GraphQL, an NFT
+ * service, or a local transaction-history cache.
+ */
+
+import { test, expect, chromium, BrowserContext, Page, Worker } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const EXTENSION_PATH = path.resolve(process.cwd(), '../web-app/dist/browser-extension-wallet');
+const PASSWORD = 'TestPass123!';
+const PRIV_KEY = '5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3';
+const PUB_KEY = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV';
+const ACCOUNT = 'ti1wr2sn3wb4';
+const NODE_URL = 'https://api.mainnet.ultra.io';
+const EXPLORER_URL = `https://explorer.mainnet.ultra.io/account/${ACCOUNT}`;
+const MAINNET_CHAIN = 'a9c481dfbc7d9506dc7e87e9a137c931b0a9303f64fd7a1d08b8230133920097';
+const NFT_CONTRACT = 'eosio.nft.ft';
+const CAPTURE_DIR = path.resolve(process.cwd(), 'output/playwright');
+
+interface RpcCall {
+    url: string;
+    body: Record<string, unknown>;
+    headers: Record<string, string>;
+}
+
+interface HomeRpcFixture {
+    calls: RpcCall[];
+    nftCalls: RpcCall[];
+    metadataCalls: RpcCall[];
+    httpRequests: Array<{ url: string; headers: Record<string, string> }>;
+}
+
+interface WalletHarness {
+    context: BrowserContext;
+    page: Page;
+    rpc: HomeRpcFixture;
+    userDataDir: string;
+}
+
+async function getServiceWorker(context: BrowserContext, timeoutMs = 10_000): Promise<Worker> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const workers = context.serviceWorkers();
+        if (workers.length > 0) return workers[0];
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(`Extension service worker did not start within ${timeoutMs}ms`);
+}
+
+/** Seed the same encrypted vault/session shape used by the existing e2e suite. */
+async function seedExtensionState(sw: Worker): Promise<void> {
+    await sw.evaluate(
+        async ({ password, pubKey, privKey, account, chainId }) => {
+            const simpleHash = (s: string): string => {
+                let h = 5381;
+                for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
+                return Math.abs(h).toString(16).padStart(8, '0');
+            };
+            const vaultFile = `${simpleHash('ultra-extension-wallet')}.json`;
+            const enc = new TextEncoder();
+            const salt = crypto.getRandomValues(new Uint8Array(32));
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const iterations = 900_000;
+            const baseKey = await crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']);
+            const aesKey = await crypto.subtle.deriveKey(
+                { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+                baseKey,
+                { name: 'AES-GCM', length: 256 },
+                false,
+                ['encrypt']
+            );
+            const plaintext = JSON.stringify({
+                keys: {
+                    [pubKey]: { publicKey: pubKey, privateKey: privKey, addedAt: Date.now(), source: 'import' },
+                },
+                accounts: [],
+            });
+            const ciphertext = new Uint8Array(
+                await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, enc.encode(plaintext))
+            );
+            const toHex = (bytes: Uint8Array): string =>
+                Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+            const encryptedVault = {
+                salt: toHex(salt),
+                iv: toHex(iv),
+                ciphertext: toHex(ciphertext),
+                iterations,
+                publicKeys: [pubKey],
+            };
+
+            await chrome.storage.local.set({
+                [vaultFile]: JSON.stringify(encryptedVault),
+                ENVIRONMENT: 'mainnet',
+                TRUSTED_APPS: { mainnet: [], testnet: [] },
+                SELECTED_ACCOUNTS_BY_CHAIN: { [chainId]: account },
+            });
+            await chrome.storage.session.set({
+                vault_session: password,
+                account_resolution_cache: {
+                    mainnet: {
+                        entries: [{ account, permission: 'active', authorizing_key: pubKey }],
+                        timestamp: Date.now(),
+                        publicKeys: [pubKey],
+                    },
+                },
+            });
+        },
+        { password: PASSWORD, pubKey: PUB_KEY, privKey: PRIV_KEY, account: ACCOUNT, chainId: MAINNET_CHAIN }
+    );
+}
+
+function parseBody(postData: string | null): Record<string, unknown> {
+    try {
+        const parsed: unknown = JSON.parse(postData ?? '{}');
+        return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : {};
+    } catch {
+        return {};
+    }
+}
+
+function uniqRows(ids: number[]): Record<string, unknown>[] {
+    return ids.map((id) => ({
+        id: String(id),
+        token_factory_id: '1001',
+        serial_number: String(id),
+        mint_date: '2026-08-10T00:00:00.000',
+        uri: `${NODE_URL}/test-metadata/${id}.json`,
+    }));
+}
+
+/**
+ * Register the broad nodeos fallback first and the feature-specific routes
+ * afterwards. Playwright evaluates the newest matching route first, so the
+ * final get_table_rows handler owns the NFT fixture while all other chain
+ * calls remain harmless and observable.
+ */
+async function mockHomeRPC(context: BrowserContext): Promise<HomeRpcFixture> {
+    const fixture: HomeRpcFixture = { calls: [], nftCalls: [], metadataCalls: [], httpRequests: [] };
+
+    context.on('request', (request) => {
+        const url = request.url();
+        if (url.startsWith('http://') || url.startsWith('https://')) {
+            fixture.httpRequests.push({ url, headers: request.headers() });
+        }
+    });
+
+    await context.route(/\/v1\/(chain|history|state)\//, async (route) => {
+        const request = route.request();
+        fixture.calls.push({
+            url: request.url(),
+            body: parseBody(request.postData()),
+            headers: request.headers(),
+        });
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    });
+
+    await context.route('**/v1/chain/get_info', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                server_version: '0',
+                chain_id: MAINNET_CHAIN,
+                head_block_num: 1,
+                last_irreversible_block_num: 1,
+                last_irreversible_block_id: '0'.repeat(64),
+                head_block_id: '0'.repeat(64),
+                head_block_time: '2026-08-10T00:00:00.000',
+                head_block_producer: 'eosio',
+                virtual_block_cpu_limit: 200000,
+                virtual_block_net_limit: 1048576000,
+                block_cpu_limit: 200000,
+                block_net_limit: 1048576,
+                server_version_string: '0.0.0',
+            }),
+        });
+    });
+
+    await context.route('**/v1/chain/get_accounts_by_authorizers', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                accounts: [{ account_name: ACCOUNT, permission_name: 'active', authorizing_key: PUB_KEY }],
+            }),
+        });
+    });
+
+    await context.route('**/test-metadata/*.json', async (route) => {
+        const request = route.request();
+        fixture.metadataCalls.push({ url: request.url(), body: {}, headers: request.headers() });
+        const id = request.url().match(/test-metadata\/(\d+)\.json/)?.[1];
+        if (id === '20') {
+            await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' });
+            return;
+        }
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ name: `Fixture UNIQ #${id}` }),
+        });
+    });
+
+    // Keep this route last: it distinguishes NFT ownership from the existing
+    // eosio.token balance/metadata table reads without changing those reads.
+    await context.route('**/v1/chain/get_table_rows', async (route) => {
+        const request = route.request();
+        const body = parseBody(request.postData());
+        const call: RpcCall = { url: request.url(), body, headers: request.headers() };
+        fixture.calls.push(call);
+
+        if (
+            body.code === NFT_CONTRACT &&
+            body.scope === ACCOUNT &&
+            (body.table === 'token.a' || body.table === 'token.b')
+        ) {
+            fixture.nftCalls.push(call);
+            const table = body.table as string;
+            const upperBound = typeof body.upper_bound === 'string' ? body.upper_bound : undefined;
+            if (table === 'token.a') {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ rows: [], more: false }),
+                });
+                return;
+            }
+            const rows =
+                upperBound === '10'
+                    ? uniqRows([10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+                    : uniqRows([20, 19, 18, 17, 16, 15, 14, 13, 12, 11]);
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(
+                    upperBound === '10' ? { rows, more: false } : { rows, more: true, next_key: '10' }
+                ),
+            });
+            return;
+        }
+
+        // Existing token balance/oracle reads are deliberately distinguished
+        // from the UNIQ fixture and receive an empty, valid nodeos response.
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ rows: [], more: false }),
+        });
+    });
+
+    return fixture;
+}
+
+async function launchWallet(): Promise<WalletHarness> {
+    const userDataDir = fs.mkdtempSync(path.join('/tmp', 'pw-wallet-home-tabs-'));
+    const context = await chromium.launchPersistentContext(userDataDir, {
+        headless: false,
+        args: [`--disable-extensions-except=${EXTENSION_PATH}`, `--load-extension=${EXTENSION_PATH}`, '--no-first-run'],
+    });
+    try {
+        const sw = await getServiceWorker(context);
+        await seedExtensionState(sw);
+        const rpc = await mockHomeRPC(context);
+        const extensionId = await sw.evaluate(() => chrome.runtime.id);
+        const page = await context.newPage();
+        await page.goto(`chrome-extension://${extensionId}/index.html#/home`);
+        await page.waitForLoadState('load');
+        await expect(page.locator('.home-container')).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByRole('tab')).toHaveCount(4, { timeout: 30_000 });
+        return { context, page, rpc, userDataDir };
+    } catch (error) {
+        await context.close();
+        fs.rmSync(userDataDir, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+async function closeWallet(harness: WalletHarness): Promise<void> {
+    await harness.context.close();
+    fs.rmSync(harness.userDataDir, { recursive: true, force: true });
+}
+
+async function captureWallet(page: Page, filename: string): Promise<void> {
+    if (process.env.WALLET_TABS_CAPTURE !== '1') return;
+    fs.mkdirSync(CAPTURE_DIR, { recursive: true });
+    await page.screenshot({ path: path.join(CAPTURE_DIR, filename), fullPage: true });
+}
+
+test.describe.configure({ timeout: 180_000 });
+
+test.describe('Wallet home tabs (real extension)', () => {
+    test.beforeAll(() => {
+        if (!fs.existsSync(path.join(EXTENSION_PATH, 'manifest.json'))) {
+            throw new Error(
+                `Extension build not found at ${EXTENSION_PATH}. Run the browser-extension-wallet production build first.`
+            );
+        }
+    });
+
+    test('renders four semantic tabs with keyboard navigation and no narrow-layout overflow', async () => {
+        const harness = await launchWallet();
+        try {
+            await harness.page.setViewportSize({ width: 320, height: 700 });
+            const tabs = harness.page.getByRole('tab');
+            await expect(tabs).toHaveText(['Tokens', 'UNIQs', 'Activities', 'Utilities']);
+            await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+            await expect(tabs.nth(0)).toHaveAttribute('tabindex', '0');
+            await expect(tabs.nth(1)).toHaveAttribute('tabindex', '-1');
+            await expect(harness.page.locator('#home-panel-tokens')).toBeVisible();
+
+            const overflow = await harness.page.evaluate(() =>
+                Math.max(
+                    document.documentElement.scrollWidth - document.documentElement.clientWidth,
+                    document.body.scrollWidth - document.body.clientWidth
+                )
+            );
+            expect(overflow, 'wallet home should fit a 320px viewport').toBeLessThanOrEqual(1);
+            await captureWallet(harness.page, 'wallet-tabs-tokens-320.png');
+
+            await tabs.nth(0).press('ArrowRight');
+            await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+            await expect(tabs.nth(1)).toBeFocused();
+
+            await tabs.nth(1).press('End');
+            await expect(tabs.nth(3)).toHaveAttribute('aria-selected', 'true');
+            await expect(tabs.nth(3)).toBeFocused();
+
+            await tabs.nth(3).press('Home');
+            await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+            await expect(tabs.nth(0)).toBeFocused();
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+
+    test('loads UNIQs lazily from standard nodeos, caps pages at ten, and paginates without duplicates', async () => {
+        const harness = await launchWallet();
+        try {
+            const { page, rpc } = harness;
+            await page.setViewportSize({ width: 320, height: 700 });
+            // Let one-time wallet boot traffic (OIDC discovery, if enabled by
+            // the production environment) settle before the feature window.
+            await page.waitForTimeout(750);
+            const featureRequestStart = rpc.httpRequests.length;
+            expect(rpc.nftCalls).toHaveLength(0);
+
+            await page.getByRole('tab', { name: 'UNIQs' }).click();
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(10);
+
+            const firstIds = await page
+                .locator('.uniq-card')
+                .evaluateAll((cards) => cards.map((card) => card.getAttribute('data-uniq-id')));
+            expect(firstIds).toEqual(['20', '19', '18', '17', '16', '15', '14', '13', '12', '11']);
+            await expect(page.locator('[data-uniq-id="20"] .s2-bold')).toHaveText('UNIQ #20');
+            await expect(page.locator('[data-uniq-id="19"] .s2-bold')).toHaveText('Fixture UNIQ #19');
+            await expect(page.locator('[data-uniq-id="19"] .uniq-card__date')).toHaveText('Minted Aug 10, 2026');
+            await captureWallet(page, 'wallet-tabs-uniqs-320.png');
+
+            expect(rpc.nftCalls.every((call) => call.body.code === NFT_CONTRACT)).toBe(true);
+            expect(rpc.nftCalls.every((call) => call.body.scope === ACCOUNT)).toBe(true);
+            expect(rpc.nftCalls.every((call) => call.body.json === true)).toBe(true);
+            expect(rpc.nftCalls.every((call) => call.body.reverse === true)).toBe(true);
+            expect(rpc.nftCalls.every((call) => !call.headers.authorization)).toBe(true);
+            expect(new Set(rpc.nftCalls.map((call) => new URL(call.url).pathname))).toEqual(
+                new Set(['/v1/chain/get_table_rows'])
+            );
+            expect(rpc.nftCalls.every((call) => call.body.limit === 10)).toBe(true);
+            expect(rpc.nftCalls.every((call) => !('lower_bound' in call.body))).toBe(true);
+            expect(rpc.nftCalls.some((call) => call.body.table === 'token.a')).toBe(true);
+            expect(rpc.nftCalls.some((call) => call.body.table === 'token.b')).toBe(true);
+
+            const homeScroll = page.locator('.home-scroll');
+            await homeScroll.evaluate((element) => {
+                element.scrollTop = element.scrollHeight;
+                element.dispatchEvent(new Event('scroll', { bubbles: true }));
+            });
+            await expect.poll(() => page.locator('.uniq-card').count(), { timeout: 30_000 }).toBe(20);
+
+            const allIds = await page
+                .locator('.uniq-card')
+                .evaluateAll((cards) => cards.map((card) => card.getAttribute('data-uniq-id')));
+            expect(allIds).toEqual([
+                '20',
+                '19',
+                '18',
+                '17',
+                '16',
+                '15',
+                '14',
+                '13',
+                '12',
+                '11',
+                '10',
+                '9',
+                '8',
+                '7',
+                '6',
+                '5',
+                '4',
+                '3',
+                '2',
+                '1',
+            ]);
+            expect(new Set(allIds).size).toBe(20);
+            expect(
+                rpc.nftCalls.filter((call) => call.body.table === 'token.b' && call.body.upper_bound === '10')
+            ).toHaveLength(1);
+            expect(
+                rpc.nftCalls.some((call) => call.body.table === 'factory.a' || call.body.table === 'factory.b')
+            ).toBe(false);
+
+            const allUrls = rpc.calls.map((call) => call.url).join('\n');
+            expect(allUrls).not.toMatch(/graphql|dfuse|history\//i);
+            const featureRequests = rpc.httpRequests.slice(featureRequestStart);
+            expect(featureRequests.length).toBeGreaterThan(0);
+            expect(new Set(featureRequests.map((request) => new URL(request.url).origin))).toEqual(
+                new Set([new URL(NODE_URL).origin])
+            );
+            expect(featureRequests.every((request) => !request.headers.authorization)).toBe(true);
+            expect(rpc.metadataCalls.every((call) => !call.headers.authorization)).toBe(true);
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+
+    test('keeps activities link-only and opens the exact Explorer/utilities destinations', async () => {
+        const harness = await launchWallet();
+        try {
+            const { context, page, rpc } = harness;
+            await page.setViewportSize({ width: 320, height: 700 });
+            await page.getByRole('tab', { name: 'Activities' }).click();
+            const activityLink = page.getByRole('link', { name: /View account activity on Explorer/i });
+            await expect(activityLink).toHaveAttribute('href', EXPLORER_URL);
+            const historyCallsBefore = rpc.calls.filter((call) => /\/history\//.test(call.url)).length;
+            await page.waitForTimeout(300);
+            expect(rpc.calls.filter((call) => /\/history\//.test(call.url))).toHaveLength(historyCallsBefore);
+            await captureWallet(page, 'wallet-tabs-activities-320.png');
+
+            const activityPagePromise = context.waitForEvent('page');
+            await activityLink.click();
+            const activityPage = await activityPagePromise;
+            await expect.poll(() => activityPage.url(), { timeout: 10_000 }).toBe(EXPLORER_URL);
+            await activityPage.close();
+
+            await page.getByRole('tab', { name: 'Utilities' }).click();
+            await captureWallet(page, 'wallet-tabs-utilities-320.png');
+            const utilityDestinations = [
+                'https://bridge.ultra.io/',
+                'https://chatroom.ultra.io/',
+                'https://toolkit.ultra.io/',
+            ];
+            await expect(page.locator('button.utility-action')).toHaveCount(3);
+            for (let index = 0; index < utilityDestinations.length; index++) {
+                const utilityPagePromise = context.waitForEvent('page');
+                await page.locator('button.utility-action').nth(index).click();
+                const utilityPage = await utilityPagePromise;
+                await expect.poll(() => utilityPage.url(), { timeout: 10_000 }).toBe(utilityDestinations[index]);
+                await utilityPage.close();
+            }
+        } finally {
+            await closeWallet(harness);
+        }
+    });
+});

--- a/tests/e2e/wallet-network-sync.e2e.spec.ts
+++ b/tests/e2e/wallet-network-sync.e2e.spec.ts
@@ -20,6 +20,7 @@
 import { test, expect, chromium, BrowserContext, Worker } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
+import { assertLocalDappExtensionBuild } from './helpers/extension-build';
 
 const EXTENSION_PATH = path.resolve(
     process.cwd(),
@@ -251,11 +252,7 @@ test.describe.configure({ timeout: 120_000 });
 
 test.describe('Wallet ↔ Toolkit network sync (real extension)', () => {
     test.beforeAll(() => {
-        if (!fs.existsSync(path.join(EXTENSION_PATH, 'manifest.json'))) {
-            throw new Error(
-                `Extension build not found at ${EXTENSION_PATH}. Run \`npm run build:browser-extension-wallet-prod\` in web-app first.`,
-            );
-        }
+        assertLocalDappExtensionBuild(EXTENSION_PATH);
     });
 
     test('switching ENVIRONMENT in BG fires accountChanged that the toolkit consumes', async () => {
@@ -923,7 +920,7 @@ test.describe('Wallet ↔ Toolkit network sync (real extension)', () => {
             // Testnet. Silent restoreSession will run Ultra.connect(true),
             // which returns network={chainId: TESTNET_CHAIN}.
             const MAINNET_URL = 'https://ultra.eosusa.io';
-            const TESTNET_URL = 'https://test.ultra.eosusa.io';
+            const TESTNET_URL = 'https://api.testnet.ultra.eossweden.org';
             await page.evaluate(({ chainId, endpoint }) => {
                 localStorage.setItem('authState', JSON.stringify({
                     type: 'ultra',

--- a/tests/e2e/wallet-sign-transaction.e2e.spec.ts
+++ b/tests/e2e/wallet-sign-transaction.e2e.spec.ts
@@ -48,6 +48,7 @@
 import { test, expect, chromium, BrowserContext, Page, Worker } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
+import { assertLocalDappExtensionBuild } from './helpers/extension-build';
 
 const EXTENSION_PATH = path.resolve(process.cwd(), '../web-app/dist/browser-extension-wallet');
 const TOOLKIT_URL = 'http://localhost:5172';
@@ -535,11 +536,7 @@ test.describe.configure({ timeout: 120_000 });
 
 test.describe('Wallet signTransaction (real extension)', () => {
   test.beforeAll(() => {
-    if (!fs.existsSync(path.join(EXTENSION_PATH, 'manifest.json'))) {
-      throw new Error(
-        `Extension build not found at ${EXTENSION_PATH}. Build it via "npx nx build browser-extension-wallet -c=production" in web-app.`,
-      );
-    }
+    assertLocalDappExtensionBuild(EXTENSION_PATH);
   });
 
   test('Default view: multi-action transaction signs and posts response to dapp', async () => {

--- a/tests/e2e/wallet-uniq-owner-actions.e2e.spec.ts
+++ b/tests/e2e/wallet-uniq-owner-actions.e2e.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Real-extension owner-action coverage for UNIQ transfer, resale, and resale
+ * cancellation. Every chain and signer endpoint is intercepted with an
+ * explicit standard nodeos fixture; the suite never sends a live write.
+ */
+
+import { test, expect, chromium, BrowserContext, Page, Worker } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { assertLocalDappExtensionBuild } from './helpers/extension-build';
+import {
+    ACCOUNT,
+    NFT_CONTRACT,
+    RECIPIENT,
+    TOKEN_ID,
+    OwnerChainRpcFixture,
+    assertNoAuthOrProhibitedTraffic,
+    mockOwnerChainRPC,
+    seedOwnerWalletState,
+} from './helpers/uniq-owner-chain-rpc';
+
+const EXTENSION_PATH = path.resolve(process.cwd(), '../web-app/dist/browser-extension-wallet');
+const CAPTURE_DIR = path.resolve(process.cwd(), 'output/playwright');
+
+interface OwnerWalletHarness {
+    context: BrowserContext;
+    page: Page;
+    sw: Worker;
+    rpc: OwnerChainRpcFixture;
+    userDataDir: string;
+}
+
+async function getServiceWorker(context: BrowserContext, timeoutMs = 10_000): Promise<Worker> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const workers = context.serviceWorkers();
+        if (workers.length > 0) return workers[0];
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(`Extension service worker did not start within ${timeoutMs}ms`);
+}
+
+async function launchOwnerWallet(options: Parameters<typeof mockOwnerChainRPC>[1] = {}): Promise<OwnerWalletHarness> {
+    const userDataDir = fs.mkdtempSync(path.join('/tmp', 'pw-wallet-uniq-owner-actions-'));
+    const context = await chromium.launchPersistentContext(userDataDir, {
+        headless: false,
+        args: [`--disable-extensions-except=${EXTENSION_PATH}`, `--load-extension=${EXTENSION_PATH}`, '--no-first-run'],
+    });
+    try {
+        const sw = await getServiceWorker(context);
+        await seedOwnerWalletState(sw);
+        const rpc = await mockOwnerChainRPC(context, options);
+        const extensionId = await sw.evaluate(() => chrome.runtime.id);
+        const page = await context.newPage();
+        await page.goto(`chrome-extension://${extensionId}/index.html#/home`);
+        await page.waitForLoadState('load');
+        await expect(page.locator('.home-container')).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByRole('tab')).toHaveCount(4, { timeout: 30_000 });
+        return { context, page, sw, rpc, userDataDir };
+    } catch (error) {
+        await context.close();
+        fs.rmSync(userDataDir, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+async function closeOwnerWallet(harness: OwnerWalletHarness): Promise<void> {
+    await harness.context.close();
+    fs.rmSync(harness.userDataDir, { recursive: true, force: true });
+}
+
+async function openOwnerDetail(page: Page): Promise<void> {
+    await page.setViewportSize({ width: 320, height: 700 });
+    await page.getByRole('tab', { name: 'UNIQs' }).click();
+    await expect(page.locator('.uniq-card')).toHaveCount(1, { timeout: 30_000 });
+    await expect(page.locator(`[data-uniq-id="${TOKEN_ID}"]`)).toBeVisible();
+    await page.locator(`[data-uniq-id="${TOKEN_ID}"]`).click();
+    await expect(page.locator('#uniq-detail-title')).toBeVisible({ timeout: 30_000 });
+}
+
+async function openActionForm(page: Page, action: 'Transfer' | 'Resell' | 'Cancel resale'): Promise<void> {
+    await expect(page.locator('.uniq-detail__actions')).toContainText(action, { timeout: 30_000 });
+    await page.locator('.uniq-detail__actions').getByRole('button', { name: action, exact: true }).click();
+    await expect(page.locator('ultra-uniq-action-form')).toBeVisible({ timeout: 30_000 });
+}
+
+async function submitActionForm(page: Page): Promise<void> {
+    await page.getByRole('button', { name: 'Continue to confirmation', exact: true }).click();
+    await expect(page).toHaveURL(/#\/sign-transaction\/uniq-action\/.+\/confirm/, { timeout: 30_000 });
+}
+
+async function confirmAction(page: Page, expectedTitle: string): Promise<void> {
+    await expect(page.locator('ultra-uniq-action-confirm')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('ultra-top-nav')).toContainText(expectedTitle);
+    await page.locator('ultra-wallet-transaction-footer').getByRole('button', { name: 'Confirm', exact: true }).click();
+}
+
+async function capture(page: Page, name: string): Promise<void> {
+    if (process.env.WALLET_TABS_CAPTURE !== '1') return;
+    fs.mkdirSync(CAPTURE_DIR, { recursive: true });
+    await page.screenshot({ path: path.join(CAPTURE_DIR, name), fullPage: true });
+}
+
+test.describe.configure({ timeout: 180_000 });
+
+test.describe('UNIQ owner actions (real extension)', () => {
+    test.beforeAll(() => {
+        assertLocalDappExtensionBuild(EXTENSION_PATH);
+    });
+
+    test('invalid transfer recipient is blocked before any authorization, ABI, or broadcast request', async () => {
+        const harness = await launchOwnerWallet();
+        try {
+            const { page, rpc } = harness;
+            await openOwnerDetail(page);
+            await openActionForm(page, 'Transfer');
+
+            await page.locator('#uniq-recipient').fill('not valid');
+            await expect(page.getByRole('button', { name: 'Continue to confirmation', exact: true })).toBeDisabled();
+            await page.waitForTimeout(300);
+
+            expect(rpc.pushRequests).toHaveLength(0);
+            expect(rpc.requiredSigningCalls).toHaveLength(0);
+            assertNoAuthOrProhibitedTraffic(rpc);
+        } finally {
+            await closeOwnerWallet(harness);
+        }
+    });
+
+    test('transfer builds the owner action, confirms, and broadcasts exactly once through mocked nodeos', async () => {
+        const harness = await launchOwnerWallet();
+        try {
+            const { page, rpc } = harness;
+            await openOwnerDetail(page);
+            await openActionForm(page, 'Transfer');
+            await page.locator('#uniq-recipient').fill(RECIPIENT);
+            await page.locator('#uniq-transfer-memo').fill('gift');
+            await submitActionForm(page);
+            await expect(page.locator('ultra-uniq-action-confirm')).toContainText(`UNIQ ID${TOKEN_ID}`);
+            await expect(page.locator('ultra-uniq-action-confirm')).toContainText(`Recipient: ${RECIPIENT}`);
+            await confirmAction(page, 'Confirm UNIQ transfer');
+
+            await expect(page.locator('ultra-transaction-status')).toContainText('Your UNIQ action', {
+                timeout: 30_000,
+            });
+            expect(rpc.pushRequests).toHaveLength(1);
+            expect(rpc.pushRequests[0].body.signatures).toEqual(expect.arrayContaining([expect.any(String)]));
+            expect(typeof rpc.pushRequests[0].body.packed_trx).toBe('string');
+            expect(String(rpc.pushRequests[0].body.packed_trx).length).toBeGreaterThan(0);
+            expect(rpc.requiredSigningCalls.filter((call) => call.url.endsWith('/get_abi'))).toHaveLength(1);
+            expect(rpc.requiredSigningCalls.filter((call) => call.body.account_name === NFT_CONTRACT)).toHaveLength(1);
+            expect(rpc.calls.some((call) => call.url.endsWith('/get_info'))).toBe(true);
+            expect(rpc.pushRequests[0].headers.authorization).toBeUndefined();
+            expect(rpc.pushRequests[0].body).toEqual(
+                expect.objectContaining({ signatures: expect.any(Array), packed_trx: expect.any(String) })
+            );
+            await capture(page, 'wallet-uniq-transfer-success-320.png');
+            assertNoAuthOrProhibitedTraffic(rpc);
+        } finally {
+            await closeOwnerWallet(harness);
+        }
+    });
+
+    test('chain rejection reaches the error route without optimistic ownership mutation and can retry', async () => {
+        const harness = await launchOwnerWallet({ push: 'failure' });
+        try {
+            const { page, rpc } = harness;
+            await openOwnerDetail(page);
+            await openActionForm(page, 'Transfer');
+            await page.locator('#uniq-recipient').fill(RECIPIENT);
+            await submitActionForm(page);
+            await confirmAction(page, 'Confirm UNIQ transfer');
+
+            await expect(page.locator('ultra-uniq-action-error')).toContainText('UNIQ action failed', {
+                timeout: 30_000,
+            });
+            expect(rpc.pushRequests).toHaveLength(1);
+            await page.getByRole('button', { name: 'Try again', exact: true }).click();
+            await expect(page).toHaveURL(new RegExp(`#\\/sign-transaction\\/uniq-action\\/transfer\\/${TOKEN_ID}$`), {
+                timeout: 30_000,
+            });
+            await expect(page.locator('ultra-uniq-action-form')).toBeVisible({ timeout: 30_000 });
+            await page.goto(page.url().replace(/#.*$/, '#/home'));
+            // openOwnerDetail first proves that the owner inventory still
+            // contains the exact token, then opens the detail overlay.
+            await openOwnerDetail(page);
+            await expect(page.locator('.uniq-detail')).toContainText(ACCOUNT);
+            expect(rpc.pushRequests).toHaveLength(1);
+            assertNoAuthOrProhibitedTraffic(rpc);
+        } finally {
+            await closeOwnerWallet(harness);
+        }
+    });
+
+    test('resell uses the selected core precision and current commission range in confirmation', async () => {
+        const harness = await launchOwnerWallet();
+        try {
+            const { page, rpc } = harness;
+            await openOwnerDetail(page);
+            await openActionForm(page, 'Resell');
+            await page.locator('#uniq-resell-price').fill('2.5');
+            await page.getByRole('button', { name: 'Advanced resale options', exact: true }).click();
+            await expect(page.locator('#uniq-promoter-rate')).toHaveValue('200');
+            await page.locator('#uniq-promoter-rate').fill('250');
+            await page.locator('#uniq-resell-memo').fill('listing');
+            await submitActionForm(page);
+            await expect(page.locator('ultra-uniq-action-confirm')).toContainText('Price: 2.50000000 UOS');
+            await expect(page.locator('ultra-uniq-action-confirm')).toContainText('Promoter reward: 250 bp');
+            await confirmAction(page, 'Confirm UNIQ resale');
+
+            await expect(page.locator('ultra-transaction-status')).toContainText('Your UNIQ action', {
+                timeout: 30_000,
+            });
+            expect(rpc.pushRequests).toHaveLength(1);
+            expect(rpc.pushRequests[0].body.signatures).toEqual(expect.arrayContaining([expect.any(String)]));
+            expect(String(rpc.pushRequests[0].body.packed_trx).length).toBeGreaterThan(0);
+            expect(rpc.requiredSigningCalls.filter((call) => call.url.endsWith('/get_abi'))).toHaveLength(1);
+            assertNoAuthOrProhibitedTraffic(rpc);
+        } finally {
+            await closeOwnerWallet(harness);
+        }
+    });
+
+    test('cancel-resale confirmation is explicit and Decline performs zero signing or broadcast calls', async () => {
+        const harness = await launchOwnerWallet({ listing: true });
+        try {
+            const { page, rpc } = harness;
+            await openOwnerDetail(page);
+            await openActionForm(page, 'Cancel resale');
+            await expect(page.locator('ultra-uniq-action-form')).toContainText('2.00000000 UOS');
+            await page.locator('#uniq-cancel-memo').fill('changed my mind');
+            await submitActionForm(page);
+            await expect(page.locator('ultra-uniq-action-confirm')).toContainText(`Current listing: 2.00000000 UOS`);
+            await expect(page.locator('ultra-top-nav')).toContainText('Confirm resale cancellation');
+
+            await page
+                .locator('ultra-wallet-transaction-footer')
+                .getByRole('button', { name: 'Decline', exact: true })
+                .click();
+            expect(rpc.pushRequests).toHaveLength(0);
+            expect(rpc.requiredSigningCalls).toHaveLength(0);
+            assertNoAuthOrProhibitedTraffic(rpc);
+        } finally {
+            await closeOwnerWallet(harness);
+        }
+    });
+});


### PR DESCRIPTION
Adds real-extension Playwright coverage for ultraio/frontend/web-app!2705.

Coverage includes the four-tab shell, keyboard accessibility, 320 px layout, 10+10 UNIQ pagination, local and exact ID search, current/legacy detail state, focus restoration, transfer/resell/cancel confirmation, real signing with deterministic mocked nodeos ABI and broadcast endpoints, chain rejection/retry, explorer-link-only Activities, and fixed Utilities destinations.

The fixtures assert exact standard nodeos requests, reject unexpected required signing endpoints, prohibit feature traffic to non-nodeos APIs, and verify no authorization header is attached. Automated tests never perform a live-chain write.

Final verification:
- focused specs: 16/16 passed
- five-repeat stability run: 80/80 passed
- full canonical Playwright suite after the final web-app audit fix: 74 passed, 1 intentional skip
- screenshot capture run: 16/16 passed

The localhost-compatible artifact preflight remains intentional because the CWS release build strips loopback access.