### PR TITLE
test(e2e): drop Ultra Chatroom from wallet Utilities coverage

### DIFF
--- a/tests/e2e/wallet-home-tabs.e2e.spec.ts
+++ b/tests/e2e/wallet-home-tabs.e2e.spec.ts
@@ -828,10 +828,9 @@ test.describe('Wallet home tabs (real extension)', () => {
             await captureWallet(page, 'wallet-tabs-utilities-320.png');
             const utilityDestinations = [
                 'https://bridge.ultra.io/',
-                'https://chatroom.ultra.io/',
                 'https://toolkit.ultra.io/',
             ];
-            await expect(page.locator('button.utility-action')).toHaveCount(3);
+            await expect(page.locator('button.utility-action')).toHaveCount(2);
             for (let index = 0; index < utilityDestinations.length; index++) {
                 const utilityPagePromise = context.waitForEvent('page');
                 await page.locator('button.utility-action').nth(index).click();


### PR DESCRIPTION
Mirrors the web-app removal of the in-development **Ultra Chatroom** demo dapp from the wallet Utilities tab.

- `wallet-home-tabs.e2e.spec.ts`: expect **2** utility actions (Bridge, Toolkit); Chatroom URL removed.

Pairs with web-app MR to remove Chatroom from `utilityActions`.